### PR TITLE
Update deprication warnings

### DIFF
--- a/terraform_setup/terraform.tf
+++ b/terraform_setup/terraform.tf
@@ -1,9 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
 provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
   region     = "${var.aws_region}"
-  version = "~> 2.7"
 }
+
 
 locals {
   # The name of the CloudFormation stack to be created for the VPC and related resources

--- a/terraform_setup/terraform.tf
+++ b/terraform_setup/terraform.tf
@@ -48,7 +48,7 @@ resource "aws_cloudformation_stack" "vpc" {
 resource "aws_cloudformation_stack" "ecs_service" {
   name = "${local.aws_ecs_service_stack_name}"
   template_body = "${file("cloudformation-templates/public-service.yml")}"
-  depends_on = ["aws_cloudformation_stack.vpc", "aws_ecr_repository.demo-app-repository"]
+  depends_on = [aws_cloudformation_stack.vpc, aws_ecr_repository.demo-app-repository]
 
   parameters = {
     ContainerMemory = 1024


### PR DESCRIPTION
when running `terraform init` , i got prompted

```
╷
│ Warning: Version constraints inside provider configuration blocks are deprecated
│ 
│   on terraform.tf line 5, in provider "aws":
│    5:   version = "~> 2.7"
│ 
│ Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future
│ version of Terraform. To silence this warning, move the provider version constraint into the required_providers block.
│ 
│ (and one more similar warning elsewhere)
╵

╷
│ Warning: Quoted references are deprecated
│ 
│   on terraform.tf line 40, in resource "aws_cloudformation_stack" "ecs_service":
│   40:   depends_on = ["aws_cloudformation_stack.vpc", "aws_ecr_repository.demo-app-repository"]
│ 
│ In this context, references are expected literally rather than in quotes. Terraform 0.11 and earlier required quotes, but quoted references are now deprecated and will
│ be removed in a future version of Terraform. Remove the quotes surrounding this reference to silence this warning.
│ 
│ (and 3 more similar warnings elsewhere)
```

i therefore forllowed [the terraform aws-build docs](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/aws-build) to [move the provider version constraint into the required_providers block](https://github.com/CircleCI-Public/circleci-demo-aws-ecs-ecr/commit/57a2aecd0d98235db00255519453e7d19b275439) and [Removed the quotes surrounding references](https://github.com/CircleCI-Public/circleci-demo-aws-ecs-ecr/commit/afa02d7072a9bbe513e6a35d2e920c1f43b67ead)